### PR TITLE
Fix logic when all conditions are required & satisfy is any

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,18 +146,21 @@ function checkConditions(settings, reference) {
 
 	const requiredSatisfied =
 		!requiredTotal || requiredTotal === requiredPassed;
-	const normalSatisfied =
-		satisfy === "ALL" ? normalPassed === normalTotal : normalPassed > 0;
+    const normalSatisfied =
+		!normalTotal ||
+		(satisfy === "ALL" ? normalPassed === normalTotal : normalPassed > 0);
 	const outcome = normalSatisfied && requiredSatisfied;
 
-	debugStr += `Passed ${normalPassed} / ${normalTotal} (need ${satisfy}, ${
-		normalSatisfied ? "pass" : "fail"
-	})`;
+	if (normalTotal > 0) {
+		debugStr += `Passed ${normalPassed} / ${normalTotal} (need ${satisfy}, ${
+			normalSatisfied ? "pass" : "fail"
+		})\n`;
+	}
 	if (requiredTotal > 0)
-		debugStr += `, and ${requiredPassed} / ${requiredTotal} required conditions (${
+		debugStr += `Passed ${requiredPassed} / ${requiredTotal} required conditions (${
 			requiredSatisfied ? "pass" : "fail"
-		})`;
-	debugStr += ` (${outcome ? "PASS" : "FAIL"})`;
+		})\n`;
+	debugStr += `Result: ${outcome ? "PASS" : "FAIL"}`;
 	if (settings.log) settings.log(debugStr);
 
 	// test the result

--- a/index.test.js
+++ b/index.test.js
@@ -161,6 +161,42 @@ const tests = {
 		satisfy: "ALL",
 		result: false,
 	},
+  "All Required - Passed, Satisfy ALL": {
+		rules: [
+			{ op: "eq", property: "text", value: "Monday", required: true },
+			{ op: "eq", property: "negative", value: "false", required: true },
+			{ op: "eq", property: "nested.val", value: 6, required: true },
+		],
+		satisfy: "ALL",
+		result: true,
+	},
+  "All Required - Passed, Satisfy ANY": {
+		rules: [
+			{ op: "eq", property: "text", value: "Monday", required: true },
+			{ op: "eq", property: "negative", value: "false", required: true },
+			{ op: "eq", property: "nested.val", value: 6, required: true },
+		],
+		satisfy: "ANY",
+		result: true,
+	},
+  "All Required - Failed, Satisfy ALL": {
+		rules: [
+			{ op: "eq", property: "text", value: "Tuesday", required: true },
+			{ op: "eq", property: "negative", value: "true", required: true },
+			{ op: "eq", property: "nested.val", value: 6, required: true },
+		],
+		satisfy: "ALL",
+		result: false,
+	},
+  "All Required - Failed, Satisfy ANY": {
+		rules: [
+			{ op: "eq", property: "text", value: "Tuesday", required: true },
+			{ op: "eq", property: "negative", value: "true", required: true },
+			{ op: "eq", property: "nested.val", value: 6, required: true },
+		],
+		satisfy: "ANY",
+		result: false,
+	},
 	"Array of strings, match some": {
 		rules: [
 			{

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "json-conditions",
-  "version": "1.0.0",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-conditions",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Simple conditional logic to evaluate against javascript objects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**What should we check?**

Does this adequately solve this issue? Any further edge cases to consider?

**What have you changed?**

This PR changes the logic that determines if all "normal" (i.e. non-required) conditions were satisfied to also account for the case where there are no normal conditions.

It accomplishes this by more closely following the corresponding logic for required conditions, so checking first if `normalTotal` is non-zero.

Additionally, since it's possible for there to be no normal conditions, the formatting of the debug statement also had to be changed a bit.

**Which issue does this solve?**

It was observed that when a set of conditions were passed that were all required along with a `satisfy` value of `ANY`, the following check would always fail, due to `satisfy` not passing and `normalPassed` being `0`:

```js
const normalSatisfied =
  satisfy === "ALL" ? normalPassed === normalTotal : normalPassed > 0;
const outcome = normalSatisfied && requiredSatisfied;
```