### PR TITLE
Fix neq condition when using alternateValue

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function checkConditions(settings, reference) {
 			case "neq":
 				result = value != targetValue;
 				if (altComparison !== null)
-					result = result || value != altComparison;
+					result = result && value != altComparison;
 				break;
 			case "gt":
 				result = value > targetValue;
@@ -130,12 +130,12 @@ function checkConditions(settings, reference) {
 			if (rule.required) requiredPassed += 1;
 			else normalPassed += 1;
 		}
-		if (!debugStr) {
-			const unary = ["absent", "present"].includes(rule.op);
-			debugStr += `(${index}) ${rule.property} (${value}) ${
-				unary ? "is" : ""
-			} ${rule.op} ${unary ? "" : targetValue}? ${result}\n`;
-		}
+		
+		const unary = ["absent", "present"].includes(rule.op);
+		debugStr += `(${index}) ${rule.property} (${value}) ${
+			unary ? "is" : ""
+		} ${rule.op} ${unary ? "" : targetValue}? ${result}\n`;
+		
 		return result;
 	});
 


### PR DESCRIPTION
This fixes a logic error with how the package handles a `neq` condition using a boolean or `true/false` string value.

Take this example:

```
const reference = {
	donation: {
		private: {
			regPayment: true,
		},
	},
};

const simpleRules = [
	{
		value: "true",
		property: "donation.private.merchPayment",
		op: "ne",
	},
	{
		value: "true",
		property: "donation.private.regPayment",
		op: "ne",
	},
];

checkConditions(
	{
		rules: simpleRules,
		satisfy: "ALL",
		log: console.log,
	},
	reference
);
```

This should return **not pass** because `donation.private.regPayment` is `true`, but the condition is `ne true`, however it currently does pass.

The reason is this block of code:

```
result = value != targetValue;
if (altComparison !== null)
    result = result && value != altComparison;
```

Breaking it down:

`result = true != 'true'` = `true` // this is true because of the type difference
`result = true || true != true = `true` // the result of the `altComparison` logic is ignored

To fix this I've changed `||` to `&&` as there should never be a scenario in the `neq` condition where the `altComparison` can get an incorrect result.

I've also fixed the logging, it was only logging the first evaluation and no subsequent ones.