### PR TITLE
Add not_contains operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ be converted to booleans.
 | startsWith | \_.toString(x).startsWith()                    |                    |
 | endsWith   | \_.toString(x).endsWith()                      |                    |
 | contains   | \_.toString(x).includes()                      |                    |
+| not_contains | !\_.toString(x).includes()                   |                    |
 
 # Array Syntax
 

--- a/index.js
+++ b/index.js
@@ -83,6 +83,9 @@ function checkConditions(settings, reference) {
 			case "contains":
 				result = toString(value).includes(targetValue);
 				break;
+			case "not_contains":
+				result = !toString(value).includes(targetValue);
+				break;
 			case "present":
 				result = !!value;
 				break;


### PR DESCRIPTION
Adding a not_contains operator to be the inverse of contains for when you want a rule to pass if something does not contain a specific string/value 

#2 